### PR TITLE
chore(targetSdk): bump android target SDK to 36

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,7 +52,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 23
-        targetSdkVersion 34
+        targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         // Enable multidex support


### PR DESCRIPTION
# Description
This pull request includes a minor update to the Android build configuration in the `android/app/build.gradle` file, specifically updating the `targetSdkVersion` to align with the latest Android SDK requirements.

[# Linked Issues](https://github.com/XPEHO/UDSP59/issues/121)

# Changes
* [`android/app/build.gradle`](diffhunk://#diff-9526ccfd1d1813ed49c39f8c54dbeb512607376a007d824b905bc8b4e4d202d9L55-R55): Updated `targetSdkVersion` from 34 to 36 to ensure compatibility with the latest Android SDK.

# Tests
How has it been tested ?

- [X] Manually
