### PR TITLE
chore(tasks): create tasks file for VsCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "sonarlint.connectedMode.project": {
+    "connectionId": "https-sonar-infra-xpeho-com-",
+    "projectKey": "UDSP59"
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Generate sources",
+            "type": "shell",
+            "command": "dart run build_runner build --delete-conflicting-outputs",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared"
+            },
+            "problemMatcher": []
+        }
+    ]
+}


### PR DESCRIPTION
This pull request introduces configuration updates to improve development tooling in the `.vscode` folder. Key changes include adding SonarLint project settings and a new task for generating sources using `build_runner`.

### Development tooling updates:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R6): Added SonarLint configuration to enable connected mode for the project with a specified `connectionId` and `projectKey`.
* [`.vscode/tasks.json`](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aR1-R21): Added a new task to automate source generation using the `dart run build_runner build` command, with options to delete conflicting outputs and configure the task as the default build task.